### PR TITLE
Include external js scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ If you want to decrypt it without saving the password you can use the option `-p
 
 	./unkiss -p cipher.html password > plain.txt
 	Password: ********
+
+#### Including external scripts
+
+The optional `-s` parameter allows to include an arbitrary number of comma-separated javascript files into the generated file's head section. This option can be useful if the encrypted content is making use of external scripts.
+
+    ./kiss plain.txt <password OR -p> -s ./script0.js,http://example.com/script1.js,... > cipher.html
+

--- a/lib/kiss.html
+++ b/lib/kiss.html
@@ -12,6 +12,7 @@
 			return false;
 		}
 	</script>
+	@@@additional_scripts@@@
 	</head>
 	<body>
 		<form action="#" method="post" name="password">

--- a/lib/kiss.js
+++ b/lib/kiss.js
@@ -14,9 +14,9 @@ try {
 	throw e;
 }
 
-if ( process.argv.length != 4 ) {
+if ( process.argv.length < 4 ) {
 
-	console.log( 'kiss: usage: kiss <FILE> <PASSWORD | -p>\n\t-p option prompts for a password (more safe)' )
+	console.log( 'kiss: usage: kiss <FILE> <PASSWORD | -p> [-s ./script0.js,http://example.com/script1.js,...]\n\n\tParameters (<mandatory> and [optional]) must be used in the specified order.\n\n\t-p option prompts for a password (more safe)\n\t-s option allows to specify a list of comma separated js files to be included in the head' )
 
 } else {
 
@@ -25,6 +25,13 @@ if ( process.argv.length != 4 ) {
 
 	var ciphertext_json = JSON.stringify( sjcl.encrypt( password, plaintext, { 'iter': 1000, 'ts': 128, 'ks': 256, 'cipher': 'aes' } ) );
 
-	console.log( html_json.replace( /@@@sjcl@@@/, sjcl_json ).replace( /@@@data@@@/, ciphertext_json ) );
+	/* Include eventual additional scripts */
+	var additional_scripts = "";
+	if( process.argv.length == 6 && process.argv[4] == '-s' ){
+		var scripts = process.argv[ 5 ].split(',');
+		scripts.forEach( script => additional_scripts += '<script src="' + script + '"></script>\n\t' );
+	}
+
+	console.log( html_json.replace( /@@@sjcl@@@/, sjcl_json ).replace( /@@@data@@@/, ciphertext_json ).replace(/@@@additional_scripts@@@/, additional_scripts ) );
 
 }


### PR DESCRIPTION
I added the ability to include javascript files into the encrypted file's head.

This functionality could turn out to be useful if  the encrypted content is an HTML snippet making use of external libraries. For example, I successfully used the new option to include a 2FA library used once the content gets decrypted.